### PR TITLE
Allow to specify a custom status when authentication fail

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,10 +45,10 @@ function Strategy(options, verify) {
     options = {};
   }
   if (!verify) { throw new TypeError('LocalStrategy requires a verify callback'); }
-  
+
   this._usernameField = options.usernameField || 'username';
   this._passwordField = options.passwordField || 'password';
-  
+
   passport.Strategy.call(this);
   this.name = 'local';
   this._verify = verify;
@@ -70,19 +70,19 @@ Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var username = lookup(req.body, this._usernameField) || lookup(req.query, this._usernameField);
   var password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
-  
+
   if (!username || !password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
   }
-  
+
   var self = this;
-  
-  function verified(err, user, info) {
+
+  function verified(err, user, info, status) {
     if (err) { return self.error(err); }
-    if (!user) { return self.fail(info); }
+    if (!user) { return self.fail(info, status); }
     self.success(user, info);
   }
-  
+
   try {
     if (self._passReqToCallback) {
       this._verify(req, username, password, verified);

--- a/test/strategy.fail.test.js
+++ b/test/strategy.fail.test.js
@@ -6,14 +6,14 @@ var chai = require('chai')
 
 
 describe('Strategy', function() {
-    
+
   describe('failing authentication', function() {
     var strategy = new Strategy(function(username, password, done) {
       return done(null, false);
     });
-    
+
     var info;
-    
+
     before(function(done) {
       chai.passport(strategy)
         .fail(function(i) {
@@ -27,19 +27,19 @@ describe('Strategy', function() {
         })
         .authenticate();
     });
-    
+
     it('should fail', function() {
       expect(info).to.be.undefined;
     });
   });
-  
+
   describe('failing authentication with info', function() {
     var strategy = new Strategy(function(username, password, done) {
       return done(null, false, { message: 'authentication failed' });
     });
-    
+
     var info;
-    
+
     before(function(done) {
       chai.passport(strategy)
         .fail(function(i) {
@@ -53,11 +53,37 @@ describe('Strategy', function() {
         })
         .authenticate();
     });
-    
+
     it('should fail', function() {
       expect(info).to.be.an('object');
       expect(info.message).to.equal('authentication failed');
     });
   });
-  
+
+  describe('failing authentication with info and status', function() {
+    var strategy = new Strategy(function(username, password, done) {
+      return done(null, false, { message: 'authentication failed' }, 403);
+    });
+
+    var status;
+
+    before(function(done) {
+      chai.passport(strategy)
+        .fail(function(i, s) {
+          status = s;
+          done();
+        })
+        .req(function(req) {
+          req.body = {};
+          req.body.username = 'johndoe';
+          req.body.password = 'secret';
+        })
+        .authenticate();
+    });
+
+    it('should fail', function() {
+      expect(status).to.equal(403);
+    });
+  });
+
 });


### PR DESCRIPTION
For a better consistency with other fails, i found useful to also have
the opportunity to suggest a status code in the verify function.